### PR TITLE
emerge-gitclone: use correct URLs for flatcar-linux

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -17,11 +17,11 @@ with open('/usr/share/flatcar/release') as release_file:
 			release = line.split('=', 1)[1].strip()
 
 # Attempt to read Git commits from this release's manifest.
-branch = 'master'
+branch = 'flatcar-master'
 commits = {}
 if release:
 	branch = 'build-' + release.split('.', 1)[0]
-	manifest = "https://raw.githubusercontent.com/coreos/manifest/v%s/release.xml" % release
+	manifest = "https://raw.githubusercontent.com/flatcar-linux/manifest/v%s/release.xml" % release
 	try:
 		from xml.dom.minidom import parseString as pxs
 		try:  # Python 3


### PR DESCRIPTION
We should use correct URLs when fetching from the remote github repo, not `coreos` but `flatcar-linux`.

Also use the correct branch name `flatcar-master`.

This PR should be merged together with https://github.com/flatcar-linux/coreos-overlay/pull/159 , https://github.com/flatcar-linux/scripts/pull/50.