### PR TITLE
emerge-gitclone: use correct branch name format for commit

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -40,6 +40,13 @@ for repo in portage.db[eroot]['vartree'].settings.repositories:
 		continue
 	commit = commits.get(repo.sync_uri.replace('//', '').replace('.git', '').split('/', 1)[-1])
 
+	# If commit points to a branch name starting with "refs/heads",
+	# "refs/heads/flatcar-build-x", then we cannot simply get its
+	# commit with the name, because the branch was not checked out.
+	# In that case we need to make the commit point to the exact
+	# remote branch name, like "refs/remotes/origin/flatcar-build-x".
+	commit = commit.replace('refs/heads/', 'refs/remotes/origin/')
+
 	print(">>> Cloning repository '%s' from '%s'..." % (repo.name, repo.sync_uri))
 
 	if os.path.isdir(repo.location):


### PR DESCRIPTION
So far `emerge-gitclone` always checked out an exact commit in SHA1 format, which was given by the default manifest.
Now that the manifest started to specify the `revision` tag also as a branch name, `emerge-gitclone` started to fail, as it cannot check out the branch name given as `refs/heads/x`. The branch `x` was not checked out at the moment.

So we need to make `emerge-gitclone` check out its exact remote branch name, like `refs/remotes/origin/x`, in case of the branch name being specified as a revision.