### PR TITLE
emerge-gitclone: do not touch commit if it is NoneType

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -43,7 +43,10 @@ for repo in portage.db[eroot]['vartree'].settings.repositories:
 	# commit with the name, because the branch was not checked out.
 	# In that case we need to make the commit point to the exact
 	# remote branch name, like "refs/remotes/origin/flatcar-build-x".
-	commit = commit.replace('refs/heads/', 'refs/remotes/origin/')
+	if commit:
+		commit = commit.replace('refs/heads/', 'refs/remotes/origin/')
+	else:
+		print("Warning: No revision found for " + repo.sync_uri)
 
 	print(">>> Cloning repository '%s' from '%s'..." % (repo.name, repo.sync_uri))
 


### PR DESCRIPTION
We should replace commit only if the commit is not of NoneType.

Otherwise it fails like that:
```
Traceback (most recent call last):
  File "/usr/lib/python-exec/python2.7/emerge-gitclone", line 46, in <module>
    commit = commit.replace('refs/heads/', 'refs/remotes/origin/')
AttributeError: 'NoneType' object has no attribute 'replace'
```
