### PR TITLE
portage update: port emerge-gitclone to python3 and fix manifest URL

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -1,6 +1,4 @@
-#!/usr/bin/python
-
-from __future__ import print_function
+#!/usr/bin/python3
 
 import os
 import shutil
@@ -22,10 +20,7 @@ if release:
 	manifest = "https://raw.githubusercontent.com/kinvolk/manifest/v%s/release.xml" % release
 	try:
 		from xml.dom.minidom import parseString as pxs
-		try:  # Python 3
-			from urllib import request as req
-		except ImportError:  # Python 2
-			import urllib2 as req
+		from urllib import request as req
 		for repo in pxs(req.urlopen(manifest).read()).getElementsByTagName('project'):
 			commits[repo.getAttribute('name')] = repo.getAttribute('revision')
 	except Exception:

--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -19,7 +19,7 @@ with open('/usr/share/flatcar/release') as release_file:
 # Attempt to read Git commits from this release's manifest.
 commits = {}
 if release:
-	manifest = "https://raw.githubusercontent.com/flatcar-linux/manifest/v%s/release.xml" % release
+	manifest = "https://raw.githubusercontent.com/kinvolk/manifest/v%s/release.xml" % release
 	try:
 		from xml.dom.minidom import parseString as pxs
 		try:  # Python 3


### PR DESCRIPTION
emerge-gitclone needs a port to python3, because updated portage (which the script imports) is python3 only now.

