### PR TITLE
emerge-gitclone: fetch correct commit in case of non-release

### DIFF
--- a/changelog/bugfixes/2022-02-10-fetch-correct-commit.md
+++ b/changelog/bugfixes/2022-02-10-fetch-correct-commit.md
@@ -1,0 +1,1 @@
+- Fetch correct commit in case of non-release in emerge-gitclone [flatcar-dev-util#7](https://github.com/flatcar-linux/flatcar-dev-util/pull/7)

--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -17,7 +17,11 @@ with open('/usr/share/flatcar/release') as release_file:
 # Attempt to read Git commits from this release's manifest.
 commits = {}
 if release:
-	manifest = "https://raw.githubusercontent.com/kinvolk/manifest/v%s/release.xml" % release
+	if "+" in release:
+		dev_build_tag = release.split("+")[1]
+		manifest = "https://raw.githubusercontent.com/kinvolk/manifest-builds/%s/%s.xml" % (dev_build_tag, dev_build_tag)
+	else:
+		manifest = "https://raw.githubusercontent.com/kinvolk/manifest/v%s/release.xml" % release
 	try:
 		from xml.dom.minidom import parseString as pxs
 		from urllib import request as req
@@ -25,6 +29,7 @@ if release:
 			commits[repo.getAttribute('name')] = repo.getAttribute('revision')
 	except Exception:
 		print(">>> Failed to read manifest commits for %s" % release)
+		sys.exit(1)
 
 synced = False
 eroot = portage.settings['EROOT']


### PR DESCRIPTION
When the given release string is for non-release like "2022.02.02+dev-flatcar-master-4742", we should fetch release.xml from a correct commit from https://raw.githubusercontent.com/kinvolk/manifest-builds/dev-flatcar-master-4742/dev-flatcar-master-4742.xml.

Without that, as the default branch contains invalid source code that was deprecated many years ago, the build could sometimes fail, e.g. when trying to build perl 5.26.2 with gcc 10.

Found when testing dev-container for https://github.com/flatcar-linux/portage-stable/pull/282.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4764/cldsv

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
