### PR TITLE
emerge-gitclone: fetch pull request commits properly

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -60,7 +60,13 @@ for repo in portage.db[eroot]['vartree'].settings.repositories:
 	subprocess.check_call(['git', 'clone', repo.sync_uri, repo.location])
 	print('>>> Git clone in %s successful' % repo.location)
 	if commit:
-		subprocess.check_call(['git', '-C', repo.location, 'checkout', commit])
+		if commit.startswith('refs/pull/'):
+			pull=commit.removeprefix('refs/')
+			nr=commit.removeprefix('refs/pull/').removesuffix('/head')
+			subprocess.check_call(['git', '-C', repo.location, 'fetch', 'origin', pull])
+			subprocess.check_call(['git', '-C', repo.location, 'checkout', '-b', 'pr{}'.format(nr), 'FETCH_HEAD'])
+		else:
+			subprocess.check_call(['git', '-C', repo.location, 'checkout', commit])
 		print('>>> Release checkout %s in %s successful' % (commit, repo.location))
 	synced = True
 


### PR DESCRIPTION
This usually doesn't happen for releases, but for development
dev-containers it might be the case that portage-stable or
coreos-overlay commit is specified as some pull request reference -
these need to be fetched differently, as refs from refs/pull usually
are not fetched by default.

CI passed: http://localhost:9091/job/os/job/manifest/5194/cldsv/ (especially the dev-container job)