### PR TITLE
emerge-gitclone: Migrate emerge-gitclone to use scripts repo tags and submodule refs

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -7,76 +7,97 @@ import sys
 
 import portage
 
-# Find the version of the currently running release.
-release = False
-with open('/usr/share/flatcar/release') as release_file:
-	for line in release_file:
-		if line.startswith('FLATCAR_RELEASE_VERSION='):
-			release = line.split('=', 1)[1].strip()
 
-# Attempt to read Git commits from this release's manifest.
-commits = {}
-if release:
-	if "+" in release:
-		dev_build_tag = release.split("+")[1]
-		manifest = "https://raw.githubusercontent.com/kinvolk/manifest-builds/%s/%s.xml" % (dev_build_tag, dev_build_tag)
-	else:
-		manifest = "https://raw.githubusercontent.com/kinvolk/manifest/v%s/release.xml" % release
-	try:
-		from xml.dom.minidom import parseString as pxs
-		from urllib import request as req
-		for repo in pxs(req.urlopen(manifest).read()).getElementsByTagName('project'):
-			commits[repo.getAttribute('name')] = repo.getAttribute('revision')
-	except Exception:
-		print(">>> Failed to read manifest commits for %s" % release)
-		sys.exit(1)
+GIT_URI = "https://github.com/flatcar-linux/{repo}.git"
+GIT_LOCATION = "/var/lib/portage/{repo}"
 
-synced = False
-eroot = portage.settings['EROOT']
-for repo in portage.db[eroot]['vartree'].settings.repositories:
-	if repo.sync_type != 'git':
-		continue
-	commit = commits.get(repo.sync_uri.replace('//', '').replace('.git', '').split('/', 1)[-1])
 
-	# If commit points to a branch name starting with "refs/heads",
-	# "refs/heads/flatcar-build-x", then we cannot simply get its
-	# commit with the name, because the branch was not checked out.
-	# In that case we need to make the commit point to the exact
-	# remote branch name, like "refs/remotes/origin/flatcar-build-x".
-	if commit:
-		commit = commit.replace('refs/heads/', 'refs/remotes/origin/')
-	else:
-		print("Warning: No revision found for " + repo.sync_uri)
+def get_release():
+    """Return the version of the currently running release."""
+    release = False
+    with open("/usr/share/flatcar/release") as release_file:
+        for line in release_file:
+            if line.startswith("FLATCAR_RELEASE_VERSION="):
+                release = line.split("=", 1)[1].strip()
 
-	print(">>> Cloning repository '%s' from '%s'..." % (repo.name, repo.sync_uri))
+    return release
 
-	if os.path.isdir(repo.location):
-		shutil.rmtree(repo.location)
-	elif os.path.lexists(repo.location):
-		os.unlink(repo.location)
 
-	print('>>> Starting git clone in %s' % repo.location)
-	os.umask(0o022)
-	subprocess.check_call(['git', 'clone', repo.sync_uri, repo.location])
-	print('>>> Git clone in %s successful' % repo.location)
-	if commit:
-		if commit.startswith('refs/pull/'):
-			pull=commit.removeprefix('refs/')
-			nr=commit.removeprefix('refs/pull/').removesuffix('/head')
-			subprocess.check_call(['git', '-C', repo.location, 'fetch', 'origin', pull])
-			subprocess.check_call(['git', '-C', repo.location, 'checkout', '-b', 'pr{}'.format(nr), 'FETCH_HEAD'])
-		else:
-			subprocess.check_call(['git', '-C', repo.location, 'checkout', commit])
-		print('>>> Release checkout %s in %s successful' % (commit, repo.location))
-	synced = True
+def get_channel():
+    """Return the channel for the current deployment"""
+    channel = None
+    with open("/usr/share/flatcar/update.conf") as update_conf:
+        for line in update_conf:
+            if line.startswith("GROUP"):
+                channel = line.split("=", 1)[1].strip()
 
-if synced:
-	# Perform normal post-sync tasks
-	configroot = portage.settings['PORTAGE_CONFIGROOT']
-	post_sync = '%s/etc/portage/bin/post_sync' % configroot
-	if os.path.exists(post_sync):
-		subprocess.check_call([post_sync])
-	subprocess.check_call(['emerge', '--check-news', '--quiet'])
-else:
-	sys.stderr.write('>>> No git repositories configured.\n')
-	sys.exit(1)
+    return channel
+
+
+def git_clone_repo(repo_url, repo_location):
+    """Clone the given repo at the given location"""
+    print(f">>> Starting git clone in {repo_location}")
+    os.umask(0o022)
+    subprocess.check_call(
+        ["git", "clone", "--recurse-submodules", repo_url, repo_location]
+    )
+    print(f">>> Git clone in {repo_location} successful")
+
+
+def sync_repo():
+    release = get_release()
+    channel = get_channel()
+    ref = f"{channel}-{release}"
+
+    repo_list = ["scripts", "coreos-overlay", "portage-stable"]
+
+    for repo in repo_list:
+        if os.path.isdir(GIT_LOCATION.format(repo=repo)) and not os.path.islink(
+            GIT_LOCATION.format(repo=repo)
+        ):
+            shutil.rmtree(GIT_LOCATION.format(repo=repo))
+        if os.path.lexists(GIT_LOCATION.format(repo=repo)):
+            os.unlink(GIT_LOCATION.format(repo=repo))
+
+        if repo == "scripts":
+            git_clone_repo(
+                repo_url=GIT_URI.format(repo=repo),
+                repo_location=GIT_LOCATION.format(repo=repo),
+            )
+
+            subprocess.check_output(
+                [
+                    "git",
+                    "-C",
+                    GIT_LOCATION.format(repo=repo),
+                    "checkout",
+                    "--recurse-submodules",
+                    ref,
+                ]
+            )
+        else:
+            print(f">>> Symlink the repository with the appropriate folder - {repo}")
+            os.symlink(
+                GIT_LOCATION.format(repo="scripts")
+                + f"/sdk_container/src/third_party/{repo}",
+                GIT_LOCATION.format(repo=repo),
+            )
+
+
+def main():
+    try:
+        sync_repo()
+        # Perform normal post-sync tasks
+        configroot = portage.settings["PORTAGE_CONFIGROOT"]
+        post_sync = "%s/etc/portage/bin/post_sync" % configroot
+        if os.path.exists(post_sync):
+            subprocess.check_call([post_sync])
+        subprocess.check_call(["emerge", "--check-news", "--quiet"])
+    except Exception as e:
+        print(e.output)
+        sys.stderr.write(">>> No git repositories configured.\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes https://github.com/flatcar-linux/Flatcar/issues/623

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>

## How to use

Run the developer container, and then run emerge-gitclone

## Testing done
```
flatcardevelopercontainer ~ # emerge-gitclone
>>> Starting git clone in /var/lib/portage/scripts
Cloning into '/var/lib/portage/scripts'...
remote: Enumerating objects: 26661, done.
remote: Counting objects: 100% (165/165), done.
remote: Compressing objects: 100% (93/93), done.
remote: Total 26661 (delta 66), reused 137 (delta 48), pack-reused 26496
Receiving objects: 100% (26661/26661), 10.16 MiB | 14.25 MiB/s, done.
Resolving deltas: 100% (15082/15082), done.
>>> Git clone in /var/lib/portage/scripts successful
>>> Setting ref for scripts: stable-3227.2.1
>>> Checkout the ref (stable-3227.2.1) in the cloned repo - scripts
Note: switching to 'stable-3227.2.1'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at ee05ee62 New version: stable-3227.2.1
>>> Starting git clone in /var/lib/portage/coreos-overlay
Cloning into '/var/lib/portage/coreos-overlay'...
remote: Enumerating objects: 101257, done.
remote: Counting objects: 100% (1375/1375), done.
remote: Compressing objects: 100% (687/687), done.
remote: Total 101257 (delta 774), reused 1223 (delta 671), pack-reused 99882
Receiving objects: 100% (101257/101257), 25.20 MiB | 16.20 MiB/s, done.
Resolving deltas: 100% (61307/61307), done.
>>> Git clone in /var/lib/portage/coreos-overlay successful
>>> Found ref for submodule repo - coreos-overlay: 8d74afd7f21a4a3f27c858eae8ef88f2a9c8e7e5
>>> Checkout the ref (8d74afd7f21a4a3f27c858eae8ef88f2a9c8e7e5) in the cloned repo - coreos-overlay
Note: switching to '8d74afd7f21a4a3f27c858eae8ef88f2a9c8e7e5'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 8d74afd7f changelog: add entries
>>> Starting git clone in /var/lib/portage/portage-stable
Cloning into '/var/lib/portage/portage-stable'...
remote: Enumerating objects: 110924, done.
remote: Counting objects: 100% (602/602), done.
remote: Compressing objects: 100% (367/367), done.
remote: Total 110924 (delta 307), reused 455 (delta 233), pack-reused 110322
Receiving objects: 100% (110924/110924), 58.66 MiB | 16.73 MiB/s, done.
Resolving deltas: 100% (61122/61122), done.
>>> Git clone in /var/lib/portage/portage-stable successful
>>> Found ref for submodule repo - portage-stable: 76754fdb899fbbefb3878b817883454e7771b782
>>> Checkout the ref (76754fdb899fbbefb3878b817883454e7771b782) in the cloned repo - portage-stable
Note: switching to '76754fdb899fbbefb3878b817883454e7771b782'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 76754fdb8 changelog: add changelog for libpcre2 10.40
>>> Setting synced as True

Performing Global Updates
(Could take a couple of minutes if you have a lot of binary packages.)
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
