### PR TITLE
Prepare github org rename

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -8,7 +8,7 @@ import sys
 import portage
 
 
-GIT_URI = "https://github.com/flatcar-linux/{repo}.git"
+GIT_URI = "https://github.com/flatcar/{repo}.git"
 GIT_LOCATION = "/var/lib/portage/{repo}"
 
 


### PR DESCRIPTION
The "flatcar-linux" org will be renamed to "flatcar". For renames, there are no redirections in place and we have to update all links.

/cc @pothos 

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>
