### PR TITLE
emerge-gitclone: Backport changes from flatcar-master (for LTS-2021)

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -32,6 +32,8 @@ def get_channel():
         for line in update_conf:
             if line.startswith("GROUP"):
                 channel = line.split("=", 1)[1].strip()
+                if channel == 'developer':
+                    channel = 'main'
 
     return channel
 

--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -20,7 +20,7 @@ def get_release():
     with open("/usr/share/flatcar/release") as release_file:
         for line in release_file:
             if line.startswith("FLATCAR_RELEASE_VERSION="):
-                release = line.split("=", 1)[1].strip()
+                release = line.split("=", 1)[1].strip().replace("+", "-", 1)
 
     return release
 

--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -10,7 +10,7 @@ import sys
 import portage
 
 
-GIT_URI = "https://github.com/flatcar-linux/%s.git"
+GIT_URI = "https://github.com/flatcar/%s.git"
 GIT_LOCATION = "/var/lib/portage/%s"
 
 


### PR DESCRIPTION
The "flatcar-linux" org will be renamed to "flatcar". For renames, there are no redirections in place and we have to update all links.