### PR TITLE
emerge-gitclone: Handle the developer channel corner case

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -30,6 +30,8 @@ def get_channel():
         for line in update_conf:
             if line.startswith("GROUP"):
                 channel = line.split("=", 1)[1].strip()
+                if channel == 'developer':
+                    channel = 'main'
 
     return channel
 

--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -18,7 +18,7 @@ def get_release():
     with open("/usr/share/flatcar/release") as release_file:
         for line in release_file:
             if line.startswith("FLATCAR_RELEASE_VERSION="):
-                release = line.split("=", 1)[1].strip()
+                release = line.split("=", 1)[1].strip().replace("+", "-", 1)
 
     return release
 


### PR DESCRIPTION
For the main branch (so for nightly builds) the group in `/usr/share/flatcar/update.conf` is not `main`, but `developer`. This needs a small translation when turning it into channel information. Without that, we are trying to checkout a nonexistent tag named `developer-3363.0.0-…` instead of `main-3363.0.0-…`, which fails.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/346/cldsv (runs together with my kola fork that implements the dev container test).