### PR TITLE
emerge-gitclone: add support for pure git refs (dev images)

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -56,9 +56,8 @@ def sync_repo():
     #   a dev build which does not necessarily have a tag on 'scripts'.
     # These version strings look like e.g. "3552.0.0+nightly-20230323-2100-4-g5d72f4ee",
     #   with "-g<checksum>" being a git ref.
-    gitref_pat=r'-g([0-9,a-f]+)$'
-    ref_match = re.search(gitref_pat,release)
-    print(f"m: {ref_match}")
+    gitref_pat=r'-g([0-9A-Fa-f]+)$'
+    ref_match = re.search(gitref_pat, release)
     if ref_match:
         git_ref=ref_match.group(1)
         print(f">>> Gitref detected in version {ref}, will check out {git_ref}.")

--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+import re
 
 import portage
 
@@ -50,6 +51,18 @@ def sync_repo():
     release = get_release()
     channel = get_channel()
     ref = f"{channel}-{release}"
+
+    # Check if release ends with a git ref. If it does we're dealing with
+    #   a dev build which does not necessarily have a tag on 'scripts'.
+    # These version strings look like e.g. "3552.0.0+nightly-20230323-2100-4-g5d72f4ee",
+    #   with "-g<checksum>" being a git ref.
+    gitref_pat=r'-g([0-9,a-f]+)$'
+    ref_match = re.search(gitref_pat,release)
+    print(f"m: {ref_match}")
+    if ref_match:
+        git_ref=ref_match.group(1)
+        print(f">>> Gitref detected in version {ref}, will check out {git_ref}.")
+        ref = git_ref
 
     repo_list = ["scripts", "coreos-overlay", "portage-stable"]
 

--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -56,10 +56,10 @@ def sync_repo():
     #   a dev build which does not necessarily have a tag on 'scripts'.
     # These version strings look like e.g. "3552.0.0+nightly-20230323-2100-4-g5d72f4ee",
     #   with "-g<checksum>" being a git ref.
-    gitref_pat=r'-g([0-9A-Fa-f]+)$'
+    gitref_pat = r'-g([0-9A-Fa-f]+)$'
     ref_match = re.search(gitref_pat, release)
     if ref_match:
-        git_ref=ref_match.group(1)
+        git_ref = ref_match.group(1)
         print(f">>> Gitref detected in version {ref}, will check out {git_ref}.")
         ref = git_ref
 


### PR DESCRIPTION
This change adds support for checking out git refs. It is useful for using dev containers on development OS images.

For releases and for nightly builds, the OS version always corresponds to a tag in the scripts repo. `emerge-gitclone` uses the OS version to check out that tag. this works well for versions like e.g.
-   alpha-3549.0.0
-   3552.0.0+nightly-20230323-2100

because corresponding tags exist in the scripts repository.

However, a development OS image build (e.g. built on a dev machine, or via CI) might use a version like e.g.
-   alpha-3549.0.0-3-g7f21ab30
-   3552.0.0+nightly-20230323-2100-4-g5d72f4ee

This version is generated by the SDK container using
```
   git describe --tags
```
in https://github.com/flatcar/scripts/blob/main/sdk_lib/sdk_container_common.sh#L49 .
`emerge-gitclone` will fail in that case because there is no tag of that name in the scripts repo.

This change detects git refs appended to OS release versions. It extracts the git ref and uses the ref instead of a tag for checking out the correct scripts repo version.