### PR TITLE
Adjust scripts following move and rename of package repositories

### DIFF
--- a/emerge-gitclone
+++ b/emerge-gitclone
@@ -87,7 +87,7 @@ def sync_repo():
         print(f">>> Gitref detected in version {ref}, will check out {git_ref}.")
         ref = git_ref
 
-    repo_list = ["scripts", "coreos-overlay", "portage-stable"]
+    repo_list = ["scripts", "flatcar-overlay", "gentoo-subset"]
 
     for repo in repo_list:
         if os.path.isdir(GIT_LOCATION.format(repo=repo)) and not os.path.islink(
@@ -108,7 +108,7 @@ def sync_repo():
             print(f">>> Symlink the repository with the appropriate folder - {repo}")
             os.symlink(
                 GIT_LOCATION.format(repo="scripts")
-                + f"/sdk_container/src/third_party/{repo}",
+                + f"/repos/{repo}",
                 GIT_LOCATION.format(repo=repo),
             )
 


### PR DESCRIPTION
# Adjust scripts following move and rename of package repositories

The portage-stable and coreos-overlay package repositories will be moved and renamed to gentoo-subset and flatcar-overlay respectively, so emerge-gitclone needs adjusting accordingly. Fortunately, this is simple.

This will need to be merged before flatcar/scripts#2121 so that the new version of emerge-gitclone can go into that PR.

## How to use

You can run this within the SDK. Even if it's not on a branch with the repo move, you can see whether the correct symlinks are set up under /var/lib/portage.

## Testing done

I did the above. It worked.